### PR TITLE
Pass callbacks to subplans during the subplan creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+
+Fix issue with callbacks being executed multiple times
+
 ## v1.0.0
 
 Initial release, see docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.1
 
-Fix issue with callbacks being executed multiple times
+Fix issue with callbacks being executed multiple times in child plans
 
 ## v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Gem Version](https://badge.fury.io/rb/wipe_out.svg)](https://rubygems.org/gems/wipe_out)
-
 # WipeOut
+
+[![Gem Version](https://badge.fury.io/rb/wipe_out.svg)](https://rubygems.org/gems/wipe_out)
 
 ![Library for removing and clearing data in Rails ActiveRecord models](https://www.globalapptesting.com/hs-fs/hubfs/blog_post_title_image_1-14.jpeg?width=1985&name=blog_post_title_image_1-14.jpeg)
 

--- a/lib/wipe_out/execution/context.rb
+++ b/lib/wipe_out/execution/context.rb
@@ -26,7 +26,6 @@ module WipeOut
       end
 
       def subexecution(sub_plan, record)
-        plan.callbacks.each { |callback| sub_plan.add_callback(callback) }
         self.class.new(sub_plan, record, config)
       end
     end

--- a/lib/wipe_out/plans/dsl.rb
+++ b/lib/wipe_out/plans/dsl.rb
@@ -72,6 +72,7 @@ module WipeOut
           plan = plan.plan if plan.is_a?(BuiltPlan)
           dsl = Dsl.new(plan)
           dsl.instance_exec(&block) if block.present?
+          @plan.callbacks.each { |callback| plan.add_callback(callback) }
 
           @plan.add_relation(name, dsl.plan)
         end

--- a/lib/wipe_out/plans/dsl.rb
+++ b/lib/wipe_out/plans/dsl.rb
@@ -66,13 +66,17 @@ module WipeOut
       # @return [nil]
       def relation(name, plan = nil, plans: nil, &block)
         if plans
+          plans.each do |build_plan|
+            forward_callbacks(@plan, build_plan.plan)
+          end
+
           @plan.add_relation_union(name, plans.map(&:plan), &block)
         else
           plan ||= Plan.new(@plan.config)
           plan = plan.plan if plan.is_a?(BuiltPlan)
           dsl = Dsl.new(plan)
           dsl.instance_exec(&block) if block.present?
-          @plan.callbacks.each { |callback| plan.add_callback(callback) }
+          forward_callbacks(@plan, plan)
 
           @plan.add_relation(name, dsl.plan)
         end
@@ -112,6 +116,11 @@ module WipeOut
       # @!visibility private
       def add_callback(callback)
         plan.add_callback(callback)
+      end
+
+      # @!visibility private
+      def forward_callbacks(source_plan, destination_plan)
+        source_plan.callbacks.each { |callback| destination_plan.add_callback(callback) }
       end
     end
   end

--- a/lib/wipe_out/version.rb
+++ b/lib/wipe_out/version.rb
@@ -1,3 +1,3 @@
 module WipeOut
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     confirmed_at { Date.new }
 
     trait :with_comments do
-      comments { build_list(:comment, 1) }
+      comments { build_list(:comment, 2) }
     end
 
     trait :with_dashboard do

--- a/spec/lib/wipe_out/execute_spec.rb
+++ b/spec/lib/wipe_out/execute_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe WipeOut::Execute do
 
       aggregate_failures "overwrites content in comments for vip user" do
         expect(vip_user.comments.count).to eq(vip_user.comments.count)
-        expect(vip_user.comments.map(&:value)).to eq(["comment"])
+        expect(vip_user.comments.map(&:value)).to eq(%w[comment comment])
       end
     end
   end

--- a/spec/lib/wipe_out/plugins/logger_spec.rb
+++ b/spec/lib/wipe_out/plugins/logger_spec.rb
@@ -1,62 +1,113 @@
 RSpec.describe WipeOut::Plugins::Logger do
-  let(:plan) do
-    WipeOut.build_plan do
-      plugin WipeOut::Plugins::Logger
+  context "when relation has a single wipe out plan" do
+    let(:plan) do
+      WipeOut.build_plan do
+        plugin WipeOut::Plugins::Logger
 
-      wipe_out :last_name, :access_tokens
+        wipe_out :last_name, :access_tokens
 
-      relation :comments do
-        relation :resource_files do
-          on_execute { |execution| execution.record.destroy! }
+        relation :comments do
+          relation :resource_files do
+            on_execute { |execution| execution.record.destroy! }
+          end
         end
+      end
+    end
+
+    it "logs all executions for all records, even from relations", :aggregate_failures do
+      logger = double(Logger)
+      logged_messages = []
+      allow(logger).to receive(:debug) { |log| logged_messages << log }
+      user = create(:user, :with_comments)
+      first_comment = user.comments.first
+      second_comment = user.comments.second
+      plan.config.logger = logger
+
+      plan.execute(user)
+
+      expect(user.comments).to eq([first_comment, second_comment])
+      expect(logged_messages).to match([
+        "[WipeOut] start plan=Plan(attributes=[:last_name, :access_tokens])",
+        "[WipeOut] executing plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
+        "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{first_comment.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{first_comment.id}",
+        "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{second_comment.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{second_comment.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
+        "[WipeOut] completed plan=Plan(attributes=[:last_name, :access_tokens])"
+      ])
+    end
+
+    describe "nested root plans with plugins" do
+      it "uses plugin only from top level root plan that's executed" do
+        user_plan = WipeOut.build_plan do
+          plugin WipeOut::Plugins::Logger
+          wipe_out :last_name, :access_tokens
+          ignore :comments
+        end
+        user_basic_plan = WipeOut.build_plan do
+          include_plan(user_plan)
+          wipe_out :last_name
+          ignore :comments, :access_tokens
+        end
+        logger = double(Logger)
+        logged_messages = []
+        user_basic_plan.config.logger = logger
+        allow(logger).to receive(:debug) { |log| logged_messages << log }
+
+        plan.execute(create(:user))
+
+        expect(logged_messages).to match([])
       end
     end
   end
 
-  it "logs all executions for all records, even from relations", :aggregate_failures do
-    logger = double(Logger)
-    logged_messages = []
-    allow(logger).to receive(:debug) { |log| logged_messages << log }
-    user = create(:user, :with_comments)
-    first_comment = user.comments.first
-    second_comment = user.comments.second
-    plan.config.logger = logger
+  context "when relation has multiple wipe out plans (plans union)" do
+    it "logs all executions for all records, even from relations", :aggregate_failures do
+      comments_plan = WipeOut.build_plan do
+        relation :resource_files do
+          on_execute { |execution| execution.record.destroy! }
+        end
+      end
 
-    plan.execute(user)
+      vip_comments_plan = WipeOut.build_plan do
+        ignore :resource_files
+      end
 
-    expect(user.comments).to eq([first_comment, second_comment])
-    expect(logged_messages).to match([
-      "[WipeOut] start plan=Plan(attributes=[:last_name, :access_tokens])",
-      "[WipeOut] executing plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
-      "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{first_comment.id}",
-      "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{first_comment.id}",
-      "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{second_comment.id}",
-      "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{second_comment.id}",
-      "[WipeOut] wiped out plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
-      "[WipeOut] completed plan=Plan(attributes=[:last_name, :access_tokens])"
-    ])
-  end
-
-  describe "nested root plans with plugins" do
-    it "uses plugin only from top level root plan that's executed" do
-      user_plan = WipeOut.build_plan do
+      plan = WipeOut.build_plan do
         plugin WipeOut::Plugins::Logger
+
         wipe_out :last_name, :access_tokens
-        ignore :comments
+
+        relation :comments, plans: [comments_plan, vip_comments_plan] do |record|
+          record.value.starts_with?("[SPECIAL]") ? vip_comments_plan : comments_plan
+        end
       end
-      user_basic_plan = WipeOut.build_plan do
-        include_plan(user_plan)
-        wipe_out :last_name
-        ignore :comments, :access_tokens
-      end
+
       logger = double(Logger)
       logged_messages = []
-      user_basic_plan.config.logger = logger
       allow(logger).to receive(:debug) { |log| logged_messages << log }
+      user = create(:user)
+      create_list(:comment, 2, user: user)
+      create_list(:comment, 2, user: user, value: "[SPECIAL] Comment")
+      plan.config.logger = logger
 
-      plan.execute(create(:user))
+      plan.execute(user)
 
-      expect(logged_messages).to match([])
+      expect(logged_messages).to match([
+        "[WipeOut] start plan=Plan(attributes=[:last_name, :access_tokens])",
+        "[WipeOut] executing plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
+        "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.first.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.first.id}",
+        "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.second.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.second.id}",
+        "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.third.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.third.id}",
+        "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.fourth.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{user.comments.fourth.id}",
+        "[WipeOut] wiped out plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
+        "[WipeOut] completed plan=Plan(attributes=[:last_name, :access_tokens])"
+      ])
     end
   end
 end

--- a/spec/lib/wipe_out/plugins/logger_spec.rb
+++ b/spec/lib/wipe_out/plugins/logger_spec.rb
@@ -18,17 +18,20 @@ RSpec.describe WipeOut::Plugins::Logger do
     logged_messages = []
     allow(logger).to receive(:debug) { |log| logged_messages << log }
     user = create(:user, :with_comments)
-    comment = user.comments.first
+    first_comment = user.comments.first
+    second_comment = user.comments.second
     plan.config.logger = logger
 
     plan.execute(user)
 
-    expect(user.comments).to eq([comment])
+    expect(user.comments).to eq([first_comment, second_comment])
     expect(logged_messages).to match([
       "[WipeOut] start plan=Plan(attributes=[:last_name, :access_tokens])",
       "[WipeOut] executing plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
-      "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{comment.id}",
-      "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{comment.id}",
+      "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{first_comment.id}",
+      "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{first_comment.id}",
+      "[WipeOut] executing plan=Plan(attributes=[]) record_class=Comment id=#{second_comment.id}",
+      "[WipeOut] wiped out plan=Plan(attributes=[]) record_class=Comment id=#{second_comment.id}",
       "[WipeOut] wiped out plan=Plan(attributes=[:last_name, :access_tokens]) record_class=User id=#{user.id}",
       "[WipeOut] completed plan=Plan(attributes=[:last_name, :access_tokens])"
     ])


### PR DESCRIPTION
## Context
I got a report that wiping out users in our system takes waaaaay toooooooo loooong. And I put on my pants, took a magnifier and went out to the forest. 

I run the wipe out for the particular user and I immediately spot that we have too many SQL commands there.
I looked at them and it turned out that those commands are triggered by a code written in a plugin that we use for the plan. To be precise code was in the `before(:execution)` callback implemented by the plugin.

Let's go step by step. Here is the plan that was under the magnifier:

```ruby
class WipeOutAuditedPlugin
  include WipeOut::Plugin

  after(:execution) do |execution|
    record = execution.record
    
    Audited::Audit.create(auditable: record, action: "wipe_out",
      audited_changes: { "wipe_out_sensitive_personal_data" => true })
  end
end

CommentPlan = WipeOut.build_plan do
  wipe_out :content
  ignore :approved
end

UserPlan = WipeOut.build_plan do
  plugin WipeOutAuditedPlugin
  
  wipe_out :first_name, :last_name

  relation :comments, CommentPlan
end
```

and when I went `UserPlan.execute(user)` I spot that the number of audit records that were being added after every comment wipe out was increasing. 

1. After wiping out the first comment we got **one** `Audited::Audit` record
2. After wiping out the second comment we got `two` `Audited::Audit` records
...
3. After wiping out the 10th comment we got `ten` `Audited::Audit` records

Crazy, isn't it? 

I thought that it's something wrong with the user, but I tried another one and... the same.
I thought that it's something with the `WipeOutAuditedPlugin`, but it was ok.

So I went into this forbidden forest area called `wipe_out`. Old military terrain.

I found out that when the plan execution goes through the relations (association) it copies all callbacks from the parent plan to the relation plan - in our case it copies callbacks (provided by the audited plugin) from `UserPlan` to `CommentPlan`.

And here, putting my magnifier really close I spot a small **BUG** hiding under the leaf and here is how it looks:

https://github.com/GlobalAppTesting/wipe_out/blob/ea6f54838789a97eaf6548461ffbbee585083ff0/lib/wipe_out/execution/execute_plan.rb#L22-L31

Here for every record of the relation (every user comment we call `execute_on_record(plan, record)` (in our case `execute_on_record(CommentPlan, comment)` and as you can see the implementation

https://github.com/GlobalAppTesting/wipe_out/blob/ea6f54838789a97eaf6548461ffbbee585083ff0/lib/wipe_out/execution/execute_plan.rb#L42-L46

it creates a sub-execution like this:

https://github.com/GlobalAppTesting/wipe_out/blob/ea6f54838789a97eaf6548461ffbbee585083ff0/lib/wipe_out/execution/context.rb#L28-L31

and here spotlight on line 29:

https://github.com/GlobalAppTesting/wipe_out/blob/ea6f54838789a97eaf6548461ffbbee585083ff0/lib/wipe_out/execution/context.rb#L29

it copies callbacks to the relation plan - the problem is that it does it for **each relation record!!!**. For all relation records the same instance of relation plan is used and this is why we get more callbacks for every wiped association.

## Solution

I considered 2 solutions:
1. Change execution to use a new relation plan instance for every relation record. 
2. Move coping callbacks from the execution phase to plan-building phase. 

The first solution sounded to me like a bit of change and also not really an eco solution (1000 comments to wipe out = 1000 instances of the `CommentPlan`) - we are in the forest - zero waste.

Thus I went the second path. Callbacks are part of the plan and for the parent plan and e.g. included_plan they are set during plan-building, so I thought that setting them for the relation plan should also happen there.

## Changes 

- Move relation plan callbacks inheriting from execution to plan-building phase. I placed it at the end so plugins added in the plan will take precedence (to perceive the current behaviour).