### PR TITLE
Use global aggregate_failures configuration

### DIFF
--- a/spec/lib/wipe_out/plans/build_plan_spec.rb
+++ b/spec/lib/wipe_out/plans/build_plan_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe WipeOut, ".build_plan" do
-  it "builds nested plan", :aggregate_failures do
+  it "builds nested plan" do
     built_plan =
       described_class.build_plan do
         wipe_out :first_name, :last_name

--- a/spec/lib/wipe_out/plugins/logger_spec.rb
+++ b/spec/lib/wipe_out/plugins/logger_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WipeOut::Plugins::Logger do
       end
     end
 
-    it "logs all executions for all records, even from relations", :aggregate_failures do
+    it "logs all executions for all records, even from relations" do
       logger = double(Logger)
       logged_messages = []
       allow(logger).to receive(:debug) { |log| logged_messages << log }
@@ -63,7 +63,7 @@ RSpec.describe WipeOut::Plugins::Logger do
   end
 
   context "when relation has multiple wipe out plans (plans union)" do
-    it "logs all executions for all records, even from relations", :aggregate_failures do
+    it "logs all executions for all records, even from relations" do
       comments_plan = WipeOut.build_plan do
         relation :resource_files do
           on_execute { |execution| execution.record.destroy! }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,5 +33,9 @@ RSpec.configure do |config|
     FactoryBot.find_definitions
   end
 
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = meta.fetch(:aggregate_failures, true)
+  end
+
   config.raise_errors_for_deprecations!
 end


### PR DESCRIPTION
### Motivation

In most, if not all, cases, we want to aggregate failures when there are multiple expectations in an example. Currently, we address this by adding the `:aggregate_failures` metadata tag to specific examples. However, this approach has a couple of issues. Firstly, engineers may inadvertently forget to add this metadata tag, and secondly, it adds cognitive load to the process. To overcome these challenges, we can enable the `aggregate_failures` globally in the `rspec_helper`.

Another possible solution would be to enable the `RSpec/MultipleExpectations` Rubocop rule. However, we don't currently use Rubocop in this repository. Even if we were to use it, the rule is designed to address a slightly different problem, which may not be an ideal fit for resolving this specific issue.

### Changes

- Added global `aggregate_failures` configuration to the `spec_helper` (it's enabled by default)
- Removed `aggregate_failures` metadata tags from rspecs